### PR TITLE
refactor: 🔨 integrate theme settings into FoldableHeading and Markdow…

### DIFF
--- a/app/(home)/notes/components/editor/features/FoldableHeading.tsx
+++ b/app/(home)/notes/components/editor/features/FoldableHeading.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React, { useState, useRef, useEffect } from 'react';
-import { ChevronRight, ChevronDown } from 'lucide-react';
+import { useThemeSettings } from '../../../hooks';
 
 interface FoldableHeadingProps {
   level: 1 | 2 | 3 | 4 | 5 | 6;
@@ -21,6 +21,8 @@ const FoldableHeading: React.FC<FoldableHeadingProps> = ({
   const [isFolded, setIsFolded] = useState(false);
   const [hasContent, setHasContent] = useState(false);
   const headingRef = useRef<HTMLHeadingElement>(null);
+
+  const { notesTheme } = useThemeSettings();
 
   // Check if this heading has content below it (not just another heading of same or higher level)
   useEffect(() => {
@@ -101,13 +103,11 @@ const FoldableHeading: React.FC<FoldableHeadingProps> = ({
     }
   };
 
-  const iconSize = level <= 2 ? 16 : 14;
-
   const renderHeading = () => {
     const props = {
       ref: headingRef,
       id,
-      className: `relative group cursor-pointer hover:bg-gray-900/40 hover:bg-opacity-20 rounded px-1 -mx-1 transition-all duration-200 ${className}`,
+      className: `relative group cursor-pointer px-1 -mx-1 transition-all duration-200 ${className}`,
       onClick: handleToggle
     };
 

--- a/app/(home)/notes/utils/markdown-render/markdownRenderer.tsx
+++ b/app/(home)/notes/utils/markdown-render/markdownRenderer.tsx
@@ -42,6 +42,8 @@ import 'prismjs/components/prism-sql';
 import { useEffect } from 'react';
 import { Skeleton } from '@/components/ui/skeleton';
 import { useTableScrollbar } from '../../hooks/ui/useTableScrollbar';
+import { cn } from '@/lib/utils';
+import { useThemeSettings } from '../../hooks';
 
 interface MarkdownRendererProps {
   content: string;
@@ -390,6 +392,8 @@ export const MemoizedMarkdown = memo<MarkdownRendererProps>(({
     return text.toLowerCase().replace(/[^\w\s-]/g, '').replace(/\s+/g, '-');
   };
 
+  const { notesTheme } = useThemeSettings();
+
   return (
     <CheckboxProvider
       selectedNote={selectedNote}
@@ -413,7 +417,10 @@ export const MemoizedMarkdown = memo<MarkdownRendererProps>(({
               <FoldableHeading
                 level={1}
                 id={id}
-                className="text-3xl font-bold text-white mb-6 mt-8 border-b border-gray-600 pb-2"
+                className={cn(
+                  "text-3xl font-bold text-white mb-6 mt-8 border-b border-gray-600 pb-2", 
+                  notesTheme === 'light' ? 'text-black' : 'text-white hover:bg-[#3B82F6]/10'
+                )}
               >
                 {children}
               </FoldableHeading>


### PR DESCRIPTION
…nRenderer

TG-27 #closed

- Added `useThemeSettings` hook to manage theme-related styles in `FoldableHeading` and `MarkdownRenderer`.
- Updated class names in `FoldableHeading` to remove unnecessary hover effects.
- Enhanced the `FoldableHeading` component to conditionally apply text color based on the current theme.